### PR TITLE
change po duplicate check to also consider an entry's occurrences

### DIFF
--- a/src/oca_pre_commit_hooks/checks_odoo_module_po.py
+++ b/src/oca_pre_commit_hooks/checks_odoo_module_po.py
@@ -268,11 +268,12 @@ class ChecksOdooModulePO:
         """
         duplicated = defaultdict(list)
         for entry in self.po_data["po"]:
+            entry: polib.POEntry
             if entry.obsolete:
                 continue
 
             # po_duplicate_message_definition
-            duplicated[hash(entry.msgid)].append(entry)
+            duplicated[(entry.msgid, tuple(entry.occurrences))].append(entry)
             for meth in utils.getattr_checks(self, self.enable, self.disable, "visit_entry"):
                 meth(entry)
 


### PR DESCRIPTION
The dicionary for duplicated po-entries only indexes by msgid. 
This PR adds the occurrences to the indexing and allows a po file to have the same msgid for different occurrences. 